### PR TITLE
Drafting proposal to allow for flexible base URL

### DIFF
--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
@@ -186,6 +186,10 @@ class OpenAIOkHttpClient private constructor() {
 
         fun fromEnv() = apply { clientOptions.fromEnv() }
 
+        fun modelInPath(modelInPath: Boolean) = apply {
+            clientOptions.modelInPath(modelInPath)
+        }
+
         /**
          * Returns an immutable instance of [OpenAIClient].
          *

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
@@ -186,8 +186,8 @@ class OpenAIOkHttpClient private constructor() {
 
         fun fromEnv() = apply { clientOptions.fromEnv() }
 
-        fun modelInPath(modelInPath: Boolean) = apply {
-            clientOptions.modelInPath(modelInPath)
+        fun unifiedAzureRoutes(unifiedAzureRoutes: Boolean) = apply {
+            clientOptions.unifiedAzureRoutes(unifiedAzureRoutes)
         }
 
         /**

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClient.kt
@@ -186,8 +186,8 @@ class OpenAIOkHttpClient private constructor() {
 
         fun fromEnv() = apply { clientOptions.fromEnv() }
 
-        fun unifiedAzureRoutes(unifiedAzureRoutes: Boolean) = apply {
-            clientOptions.unifiedAzureRoutes(unifiedAzureRoutes)
+        fun azureLegacyPaths(azureLegacyPaths: Boolean) = apply {
+            clientOptions.azureLegacyPaths(azureLegacyPaths)
         }
 
         /**

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClientAsync.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClientAsync.kt
@@ -186,8 +186,8 @@ class OpenAIOkHttpClientAsync private constructor() {
 
         fun fromEnv() = apply { clientOptions.fromEnv() }
 
-        fun modelInPath(modelInPath: Boolean) = apply {
-            clientOptions.modelInPath(modelInPath)
+        fun unifiedAzureRoutes(unifiedAzureRoutes: Boolean) = apply {
+            clientOptions.unifiedAzureRoutes(unifiedAzureRoutes)
         }
         /**
          * Returns an immutable instance of [OpenAIClientAsync].

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClientAsync.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClientAsync.kt
@@ -186,6 +186,9 @@ class OpenAIOkHttpClientAsync private constructor() {
 
         fun fromEnv() = apply { clientOptions.fromEnv() }
 
+        fun modelInPath(modelInPath: Boolean) = apply {
+            clientOptions.modelInPath(modelInPath)
+        }
         /**
          * Returns an immutable instance of [OpenAIClientAsync].
          *

--- a/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClientAsync.kt
+++ b/openai-java-client-okhttp/src/main/kotlin/com/openai/client/okhttp/OpenAIOkHttpClientAsync.kt
@@ -186,8 +186,8 @@ class OpenAIOkHttpClientAsync private constructor() {
 
         fun fromEnv() = apply { clientOptions.fromEnv() }
 
-        fun unifiedAzureRoutes(unifiedAzureRoutes: Boolean) = apply {
-            clientOptions.unifiedAzureRoutes(unifiedAzureRoutes)
+        fun azureLegacyPaths(azureLegacyPaths: Boolean) = apply {
+            clientOptions.azureLegacyPaths(azureLegacyPaths)
         }
         /**
          * Returns an immutable instance of [OpenAIClientAsync].

--- a/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
@@ -13,13 +13,12 @@ internal fun HttpRequest.Builder.addPathSegmentsForAzure(
 ): HttpRequest.Builder = apply {
     val baseUrl = clientOptions.baseUrl()
     if (isAzureEndpoint(baseUrl)) {
-        addPathSegment("openai")
         // Users can toggle off unified Azure routes using the "unifiedAzureRoutes" option.
-        if (clientOptions.unifiedAzureRoutes && isAzureUnifiedEndpoint(baseUrl)) {
-            addPathSegment("v1")
-        } else {
+        // Endpoints are assumed to be provided with `/v1/openai` in their path already.
+        if (!clientOptions.unifiedAzureRoutes || !isAzureUnifiedEndpoint(baseUrl)) {
             // Unknown Azure endpoints and legacy Azure endpoints are treated the old way.
             // We are assuming in this branch that isAzureLegacyEndpoint(baseUrl) would be true for this base URL.
+            addPathSegment("openai")
             deploymentModel?.let { addPathSegments("deployments", it) }
         }
     }

--- a/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
@@ -10,7 +10,7 @@ internal fun HttpRequest.Builder.addPathSegmentsForAzure(
     clientOptions: ClientOptions,
     deploymentModel: String?,
 ): HttpRequest.Builder = apply {
-    if (isAzureEndpoint(clientOptions.baseUrl())) {
+    if (isAzureEndpoint(clientOptions.baseUrl()) || clientOptions.modelInPath) {
         addPathSegment("openai")
         deploymentModel?.let { addPathSegments("deployments", it) }
     }

--- a/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
@@ -3,7 +3,7 @@ package com.openai.azure
 import com.openai.core.ClientOptions
 import com.openai.core.http.HttpRequest
 import com.openai.core.isAzureEndpoint
-import com.openai.core.isAzureUnifiedEndpoint
+import com.openai.core.isAzureUnifiedEndpointPath
 import com.openai.credential.BearerTokenCredential
 
 @JvmSynthetic
@@ -15,7 +15,7 @@ internal fun HttpRequest.Builder.addPathSegmentsForAzure(
     if (isAzureEndpoint(baseUrl)) {
         // Users can toggle off unified Azure routes using the "unifiedAzureRoutes" option.
         // Endpoints are assumed to be provided with `/v1/openai` in their path already.
-        if (!clientOptions.unifiedAzureRoutes || !isAzureUnifiedEndpoint(baseUrl)) {
+        if (clientOptions.azureLegacyPaths && !isAzureUnifiedEndpointPath(baseUrl)) {
             // Unknown Azure endpoints and legacy Azure endpoints are treated the old way.
             // We are assuming in this branch that isAzureLegacyEndpoint(baseUrl) would be true for this base URL.
             addPathSegment("openai")

--- a/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
@@ -3,6 +3,7 @@ package com.openai.azure
 import com.openai.core.ClientOptions
 import com.openai.core.http.HttpRequest
 import com.openai.core.isAzureEndpoint
+import com.openai.core.isAzureUnifiedEndpoint
 import com.openai.credential.BearerTokenCredential
 
 @JvmSynthetic
@@ -10,9 +11,17 @@ internal fun HttpRequest.Builder.addPathSegmentsForAzure(
     clientOptions: ClientOptions,
     deploymentModel: String?,
 ): HttpRequest.Builder = apply {
-    if (isAzureEndpoint(clientOptions.baseUrl()) || clientOptions.modelInPath) {
+    val baseUrl = clientOptions.baseUrl()
+    if (isAzureEndpoint(baseUrl)) {
         addPathSegment("openai")
-        deploymentModel?.let { addPathSegments("deployments", it) }
+        // Users can toggle off unified Azure routes using the "unifiedAzureRoutes" option.
+        if (clientOptions.unifiedAzureRoutes && isAzureUnifiedEndpoint(baseUrl)) {
+            addPathSegment("v1")
+        } else {
+            // Unknown Azure endpoints and legacy Azure endpoints are treated the old way.
+            // We are assuming in this branch that isAzureLegacyEndpoint(baseUrl) would be true for this base URL.
+            deploymentModel?.let { addPathSegments("deployments", it) }
+        }
     }
 }
 

--- a/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/azure/HttpRequestBuilderExtensions.kt
@@ -15,7 +15,7 @@ internal fun HttpRequest.Builder.addPathSegmentsForAzure(
     if (isAzureEndpoint(baseUrl)) {
         // Users can toggle off unified Azure routes using the "unifiedAzureRoutes" option.
         // Endpoints are assumed to be provided with `/v1/openai` in their path already.
-        if (clientOptions.azureLegacyPaths && !isAzureUnifiedEndpointPath(baseUrl)) {
+        if (clientOptions.azureLegacyPaths || !isAzureUnifiedEndpointPath(baseUrl)) {
             // Unknown Azure endpoints and legacy Azure endpoints are treated the old way.
             // We are assuming in this branch that isAzureLegacyEndpoint(baseUrl) would be true for this base URL.
             addPathSegment("openai")

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -36,7 +36,7 @@ private constructor(
     @get:JvmName("maxRetries") val maxRetries: Int,
     @get:JvmName("credential") val credential: Credential,
     @get:JvmName("azureServiceVersion") val azureServiceVersion: AzureOpenAIServiceVersion?,
-    @get:JvmName("unifiedAzureRoutes") val unifiedAzureRoutes: Boolean = true,
+    @get:JvmName("azureLegacyPaths") val azureLegacyPaths: Boolean = false,
     private val organization: String?,
     private val project: String?,
     private val webhookSecret: String?,
@@ -95,7 +95,7 @@ private constructor(
         private var organization: String? = null
         private var project: String? = null
         private var webhookSecret: String? = null
-        private var unifiedAzureRoutes: Boolean = true
+        private var azureLegacyPaths: Boolean = true
 
         @JvmSynthetic
         internal fun from(clientOptions: ClientOptions) = apply {
@@ -115,7 +115,7 @@ private constructor(
             organization = clientOptions.organization
             project = clientOptions.project
             webhookSecret = clientOptions.webhookSecret
-            unifiedAzureRoutes = clientOptions.unifiedAzureRoutes
+            azureLegacyPaths = clientOptions.azureLegacyPaths
         }
 
         fun httpClient(httpClient: HttpClient) = apply {
@@ -282,7 +282,7 @@ private constructor(
             }
         }
 
-        fun unifiedAzureRoutes(unifiedAzureRoutes: Boolean) = apply { this.unifiedAzureRoutes = unifiedAzureRoutes }
+        fun azureLegacyPaths(unifiedAzureRoutes: Boolean) = apply { this.azureLegacyPaths = unifiedAzureRoutes }
 
         /**
          * Returns an immutable instance of [ClientOptions].
@@ -328,7 +328,7 @@ private constructor(
             baseUrl?.let {
                 if (isAzureEndpoint(it)) {
                     // Non Azure-unified routes will still require an api-version value.
-                    if (!unifiedAzureRoutes || !isAzureUnifiedEndpoint(it)) {
+                    if (!azureLegacyPaths || !isAzureUnifiedEndpointPath(it)) {
                         replaceQueryParams(
                             "api-version",
                             (azureServiceVersion ?: AzureOpenAIServiceVersion.latestStableVersion())
@@ -379,7 +379,7 @@ private constructor(
                 maxRetries,
                 credential,
                 azureServiceVersion,
-                unifiedAzureRoutes,
+                azureLegacyPaths,
                 organization,
                 project,
                 webhookSecret,

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -95,7 +95,7 @@ private constructor(
         private var organization: String? = null
         private var project: String? = null
         private var webhookSecret: String? = null
-        private var azureLegacyPaths: Boolean = true
+        private var azureLegacyPaths: Boolean = false
 
         @JvmSynthetic
         internal fun from(clientOptions: ClientOptions) = apply {
@@ -282,7 +282,7 @@ private constructor(
             }
         }
 
-        fun azureLegacyPaths(unifiedAzureRoutes: Boolean) = apply { this.azureLegacyPaths = unifiedAzureRoutes }
+        fun azureLegacyPaths(azureLegacyPaths: Boolean) = apply { this.azureLegacyPaths = azureLegacyPaths }
 
         /**
          * Returns an immutable instance of [ClientOptions].

--- a/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/ClientOptions.kt
@@ -36,6 +36,7 @@ private constructor(
     @get:JvmName("maxRetries") val maxRetries: Int,
     @get:JvmName("credential") val credential: Credential,
     @get:JvmName("azureServiceVersion") val azureServiceVersion: AzureOpenAIServiceVersion?,
+    @get:JvmName("modelInPath") val modelInPath: Boolean = false,
     private val organization: String?,
     private val project: String?,
     private val webhookSecret: String?,
@@ -93,6 +94,7 @@ private constructor(
         private var azureServiceVersion: AzureOpenAIServiceVersion? = null
         private var organization: String? = null
         private var project: String? = null
+        private var modelInPath: Boolean = false
         private var webhookSecret: String? = null
 
         @JvmSynthetic
@@ -113,6 +115,7 @@ private constructor(
             organization = clientOptions.organization
             project = clientOptions.project
             webhookSecret = clientOptions.webhookSecret
+            modelInPath = clientOptions.modelInPath
         }
 
         fun httpClient(httpClient: HttpClient) = apply {
@@ -279,6 +282,8 @@ private constructor(
             }
         }
 
+        fun modelInPath(modelInPath: Boolean) = apply { this.modelInPath = modelInPath }
+
         /**
          * Returns an immutable instance of [ClientOptions].
          *
@@ -368,6 +373,7 @@ private constructor(
                 maxRetries,
                 credential,
                 azureServiceVersion,
+                modelInPath,
                 organization,
                 project,
                 webhookSecret,

--- a/openai-java-core/src/main/kotlin/com/openai/core/Utils.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/Utils.kt
@@ -91,13 +91,27 @@ internal fun Any?.contentToString(): String {
 
 @JvmSynthetic
 internal fun isAzureEndpoint(baseUrl: String): Boolean {
-    // Azure Endpoint should be in the format of `https://<region>.openai.azure.com`.
+    // Azure legacy endpoint should be in the format of `https://<region>.openai.azure.com`.
+    // Or Azure unified endpoint should be in the format of `https://<region>.services.ai.azure.com`.
     // Or `https://<region>.azure-api.net` for Azure OpenAI Management URL.
     // Or `<user>-random-<region>.cognitiveservices.azure.com`.
     val trimmedBaseUrl = baseUrl.trim().trimEnd('/')
-    return trimmedBaseUrl.endsWith(".openai.azure.com", true) ||
+    return isAzureLegacyEndpoint(trimmedBaseUrl) || isAzureUnifiedEndpoint(baseUrl) ||
+        // exceptions:
         trimmedBaseUrl.endsWith(".azure-api.net", true) ||
         trimmedBaseUrl.endsWith(".cognitiveservices.azure.com", true)
+}
+
+@JvmSynthetic
+internal fun isAzureLegacyEndpoint(baseUrl: String): Boolean {
+    val trimmedBaseUrl = baseUrl.trim().trimEnd('/')
+    return trimmedBaseUrl.endsWith(".openai.azure.com", true)
+}
+
+@JvmSynthetic
+internal fun isAzureUnifiedEndpoint(baseUrl: String): Boolean {
+    val trimmedBaseUrl = baseUrl.trim().trimEnd('/')
+    return trimmedBaseUrl.endsWith(".services.ai.azure.com", true)
 }
 
 internal interface Enum

--- a/openai-java-core/src/main/kotlin/com/openai/core/Utils.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/Utils.kt
@@ -122,6 +122,6 @@ internal fun URI.isOtherAzureKnownEndpoint(): Boolean =
  * Convenience function to check if the given [baseUrl] is an Azure OpenAI resource URL with the unified schema.
  */
 @JvmSynthetic
-internal fun isAzureUnifiedEndpoint(baseUrl: String): Boolean = baseUrl.trimEnd('/').endsWith("openai/v1")
+internal fun isAzureUnifiedEndpointPath(baseUrl: String): Boolean = baseUrl.trimEnd('/').endsWith("openai/v1")
 
 internal interface Enum

--- a/openai-java-core/src/main/kotlin/com/openai/core/Utils.kt
+++ b/openai-java-core/src/main/kotlin/com/openai/core/Utils.kt
@@ -122,9 +122,6 @@ internal fun URI.isOtherAzureKnownEndpoint(): Boolean =
  * Convenience function to check if the given [baseUrl] is an Azure OpenAI resource URL with the unified schema.
  */
 @JvmSynthetic
-internal fun isAzureUnifiedEndpoint(baseUrl: String): Boolean {
-    val url = URI.create(baseUrl.trim().trimEnd('/'))
-    return url.isAzureUnifiedEndpoint()
-}
+internal fun isAzureUnifiedEndpoint(baseUrl: String): Boolean = baseUrl.trimEnd('/').endsWith("openai/v1")
 
 internal interface Enum

--- a/openai-java-core/src/test/kotlin/com/openai/core/UtilsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/UtilsTest.kt
@@ -59,15 +59,17 @@ internal class UtilsTest {
     @Test
     fun isAzureUnifiedEndpoint() {
         // Valid Azure unified endpoints
-        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com")).isTrue()
-        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com/")).isTrue()
+        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com/openai/v1")).isTrue()
+        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com/openai/v1/")).isTrue()
 
         // Invalid Azure unified endpoints
+        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com")).isFalse()
+        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com/")).isFalse()
         assertThat(isAzureUnifiedEndpoint("https://region.openai.azure.com")).isFalse()
         assertThat(isAzureUnifiedEndpoint("https://example.com")).isFalse()
         assertThat(isAzureUnifiedEndpoint("https://region.openai.com")).isFalse()
         assertThat(isAzureUnifiedEndpoint("https://region.azure.com")).isFalse()
-        assertThrows<NullPointerException>{isAzureUnifiedEndpoint("")}
-        assertThrows<NullPointerException>{isAzureUnifiedEndpoint("   ")}
+        assertThat(isAzureUnifiedEndpoint("")).isFalse()
+        assertThat(isAzureUnifiedEndpoint("    ")).isFalse()
     }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/UtilsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/UtilsTest.kt
@@ -2,6 +2,7 @@ package com.openai.core
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class UtilsTest {
     @Test
@@ -34,33 +35,25 @@ internal class UtilsTest {
     @Test
     fun isAzureEndpoint() {
         // Valid Azure endpoints
+
+        // legacy
         assertThat(isAzureEndpoint("https://region.openai.azure.com")).isTrue()
         assertThat(isAzureEndpoint("https://region.openai.azure.com/")).isTrue()
+        // unified with OpenAI
+        assertThat(isAzureEndpoint("https://region.services.ai.azure.com")).isTrue()
+        assertThat(isAzureEndpoint("https://region.services.ai.azure.com/")).isTrue()
+        // other known valid schemas
         assertThat(isAzureEndpoint("https://region.azure-api.net")).isTrue()
         assertThat(isAzureEndpoint("https://region.azure-api.net/")).isTrue()
+        assertThat(isAzureEndpoint("https://region.cognitiveservices.azure.com")).isTrue()
+        assertThat(isAzureEndpoint("https://region.cognitiveservices.azure.com/")).isTrue()
 
         // Invalid Azure endpoints
         assertThat(isAzureEndpoint("https://example.com")).isFalse()
         assertThat(isAzureEndpoint("https://region.openai.com")).isFalse()
         assertThat(isAzureEndpoint("https://region.azure.com")).isFalse()
-        assertThat(isAzureEndpoint("")).isFalse()
-        assertThat(isAzureEndpoint("   ")).isFalse()
-    }
-
-    @Test
-    fun isAzureLegacyEndpoint() {
-        // Valid Azure legacy endpoints
-        assertThat(isAzureLegacyEndpoint("https://region.openai.azure.com")).isTrue()
-        assertThat(isAzureLegacyEndpoint("https://region.openai.azure.com/")).isTrue()
-
-        // Invalid Azure legacy endpoints
-        assertThat(isAzureLegacyEndpoint("https://region.azure-api.net")).isFalse()
-        assertThat(isAzureLegacyEndpoint("https://region.services.ai.azure.com")).isFalse()
-        assertThat(isAzureLegacyEndpoint("https://example.com")).isFalse()
-        assertThat(isAzureLegacyEndpoint("https://region.openai.com")).isFalse()
-        assertThat(isAzureLegacyEndpoint("https://region.azure.com")).isFalse()
-        assertThat(isAzureLegacyEndpoint("")).isFalse()
-        assertThat(isAzureLegacyEndpoint("   ")).isFalse()
+        assertThrows<NullPointerException> {isAzureEndpoint("")}
+        assertThrows<NullPointerException>{isAzureEndpoint("   ")}
     }
 
     @Test
@@ -74,7 +67,7 @@ internal class UtilsTest {
         assertThat(isAzureUnifiedEndpoint("https://example.com")).isFalse()
         assertThat(isAzureUnifiedEndpoint("https://region.openai.com")).isFalse()
         assertThat(isAzureUnifiedEndpoint("https://region.azure.com")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("   ")).isFalse()
+        assertThrows<NullPointerException>{isAzureUnifiedEndpoint("")}
+        assertThrows<NullPointerException>{isAzureUnifiedEndpoint("   ")}
     }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/UtilsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/UtilsTest.kt
@@ -46,4 +46,35 @@ internal class UtilsTest {
         assertThat(isAzureEndpoint("")).isFalse()
         assertThat(isAzureEndpoint("   ")).isFalse()
     }
+
+    @Test
+    fun isAzureLegacyEndpoint() {
+        // Valid Azure legacy endpoints
+        assertThat(isAzureLegacyEndpoint("https://region.openai.azure.com")).isTrue()
+        assertThat(isAzureLegacyEndpoint("https://region.openai.azure.com/")).isTrue()
+
+        // Invalid Azure legacy endpoints
+        assertThat(isAzureLegacyEndpoint("https://region.azure-api.net")).isFalse()
+        assertThat(isAzureLegacyEndpoint("https://region.services.ai.azure.com")).isFalse()
+        assertThat(isAzureLegacyEndpoint("https://example.com")).isFalse()
+        assertThat(isAzureLegacyEndpoint("https://region.openai.com")).isFalse()
+        assertThat(isAzureLegacyEndpoint("https://region.azure.com")).isFalse()
+        assertThat(isAzureLegacyEndpoint("")).isFalse()
+        assertThat(isAzureLegacyEndpoint("   ")).isFalse()
+    }
+
+    @Test
+    fun isAzureUnifiedEndpoint() {
+        // Valid Azure unified endpoints
+        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com")).isTrue()
+        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com/")).isTrue()
+
+        // Invalid Azure unified endpoints
+        assertThat(isAzureUnifiedEndpoint("https://region.openai.azure.com")).isFalse()
+        assertThat(isAzureUnifiedEndpoint("https://example.com")).isFalse()
+        assertThat(isAzureUnifiedEndpoint("https://region.openai.com")).isFalse()
+        assertThat(isAzureUnifiedEndpoint("https://region.azure.com")).isFalse()
+        assertThat(isAzureUnifiedEndpoint("")).isFalse()
+        assertThat(isAzureUnifiedEndpoint("   ")).isFalse()
+    }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/UtilsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/UtilsTest.kt
@@ -59,17 +59,17 @@ internal class UtilsTest {
     @Test
     fun isAzureUnifiedEndpoint() {
         // Valid Azure unified endpoints
-        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com/openai/v1")).isTrue()
-        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com/openai/v1/")).isTrue()
+        assertThat(isAzureUnifiedEndpointPath("https://region.services.ai.azure.com/openai/v1")).isTrue()
+        assertThat(isAzureUnifiedEndpointPath("https://region.services.ai.azure.com/openai/v1/")).isTrue()
 
         // Invalid Azure unified endpoints
-        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("https://region.services.ai.azure.com/")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("https://region.openai.azure.com")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("https://example.com")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("https://region.openai.com")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("https://region.azure.com")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("")).isFalse()
-        assertThat(isAzureUnifiedEndpoint("    ")).isFalse()
+        assertThat(isAzureUnifiedEndpointPath("https://region.services.ai.azure.com")).isFalse()
+        assertThat(isAzureUnifiedEndpointPath("https://region.services.ai.azure.com/")).isFalse()
+        assertThat(isAzureUnifiedEndpointPath("https://region.openai.azure.com")).isFalse()
+        assertThat(isAzureUnifiedEndpointPath("https://example.com")).isFalse()
+        assertThat(isAzureUnifiedEndpointPath("https://region.openai.com")).isFalse()
+        assertThat(isAzureUnifiedEndpointPath("https://region.azure.com")).isFalse()
+        assertThat(isAzureUnifiedEndpointPath("")).isFalse()
+        assertThat(isAzureUnifiedEndpointPath("    ")).isFalse()
     }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/ClientOptionsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/ClientOptionsTest.kt
@@ -67,7 +67,7 @@ internal class ClientOptionsTest {
     }
 
     @Test
-    fun modelInPathTestSetFalse() {
+    fun unifiedAzureRoutesTestSetFalse() {
         val clientOptions =
             ClientOptions.builder()
                 .httpClient(createOkHttpClient())
@@ -79,7 +79,7 @@ internal class ClientOptionsTest {
     }
 
     @Test
-    fun modelInPathTestDefaultTrue() {
+    fun unifiedAzureRoutesTestDefaultTrue() {
         val clientOptions =
             ClientOptions.builder()
                 .httpClient(createOkHttpClient())

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/ClientOptionsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/ClientOptionsTest.kt
@@ -67,25 +67,25 @@ internal class ClientOptionsTest {
     }
 
     @Test
-    fun modelInPathTestSet() {
+    fun modelInPathTestSetFalse() {
         val clientOptions =
             ClientOptions.builder()
-                .httpClient(createOkHttpClient("https://api.openai.com/v1"))
+                .httpClient(createOkHttpClient())
                 .credential(BearerTokenCredential.create(FAKE_API_KEY))
-                .modelInPath(true)
+                .unifiedAzureRoutes(false)
                 .build()
 
-        assertThat(clientOptions.modelInPath).isTrue()
+        assertThat(clientOptions.unifiedAzureRoutes).isFalse()
     }
 
     @Test
-    fun modelInPathTestDefaultFalse() {
+    fun modelInPathTestDefaultTrue() {
         val clientOptions =
             ClientOptions.builder()
-                .httpClient(createOkHttpClient("https://api.openai.com/v1"))
+                .httpClient(createOkHttpClient())
                 .credential(BearerTokenCredential.create(FAKE_API_KEY))
                 .build()
 
-        assertThat(clientOptions.modelInPath).isFalse()
+        assertThat(clientOptions.unifiedAzureRoutes).isTrue()
     }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/ClientOptionsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/ClientOptionsTest.kt
@@ -65,4 +65,27 @@ internal class ClientOptionsTest {
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("Azure API key cannot be empty.")
     }
+
+    @Test
+    fun modelInPathTestSet() {
+        val clientOptions =
+            ClientOptions.builder()
+                .httpClient(createOkHttpClient("https://api.openai.com/v1"))
+                .credential(BearerTokenCredential.create(FAKE_API_KEY))
+                .modelInPath(true)
+                .build()
+
+        assertThat(clientOptions.modelInPath).isTrue()
+    }
+
+    @Test
+    fun modelInPathTestDefaultFalse() {
+        val clientOptions =
+            ClientOptions.builder()
+                .httpClient(createOkHttpClient("https://api.openai.com/v1"))
+                .credential(BearerTokenCredential.create(FAKE_API_KEY))
+                .build()
+
+        assertThat(clientOptions.modelInPath).isFalse()
+    }
 }

--- a/openai-java-core/src/test/kotlin/com/openai/core/http/ClientOptionsTest.kt
+++ b/openai-java-core/src/test/kotlin/com/openai/core/http/ClientOptionsTest.kt
@@ -67,25 +67,25 @@ internal class ClientOptionsTest {
     }
 
     @Test
-    fun unifiedAzureRoutesTestSetFalse() {
+    fun azureLegacyPathsTestSetTrue() {
         val clientOptions =
             ClientOptions.builder()
                 .httpClient(createOkHttpClient())
                 .credential(BearerTokenCredential.create(FAKE_API_KEY))
-                .unifiedAzureRoutes(false)
+                .azureLegacyPaths(true)
                 .build()
 
-        assertThat(clientOptions.unifiedAzureRoutes).isFalse()
+        assertThat(clientOptions.azureLegacyPaths).isTrue()
     }
 
     @Test
-    fun unifiedAzureRoutesTestDefaultTrue() {
+    fun azureLegacyPathsTestDefaultFalse() {
         val clientOptions =
             ClientOptions.builder()
                 .httpClient(createOkHttpClient())
                 .credential(BearerTokenCredential.create(FAKE_API_KEY))
                 .build()
 
-        assertThat(clientOptions.unifiedAzureRoutes).isTrue()
+        assertThat(clientOptions.azureLegacyPaths).isTrue()
     }
 }

--- a/openai-java-example/src/main/java/com/openai/example/AzureDisabledUnifiedEndpointsExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/AzureDisabledUnifiedEndpointsExample.java
@@ -1,29 +1,27 @@
 package com.openai.example;
 
-import com.azure.identity.AuthenticationUtil;
-import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
-import com.openai.credential.BearerTokenCredential;
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 
-public final class AzureEntraIdExample {
-    private AzureEntraIdExample() {}
+public final class AzureDisabledUnifiedEndpointsExample {
+    private AzureDisabledUnifiedEndpointsExample() {}
 
     public static void main(String[] args) {
         OpenAIClient client = OpenAIOkHttpClient.builder()
                 // Gets the API key from the `AZURE_OPENAI_KEY` environment variable
                 .fromEnv()
-                // Set the Azure Entra ID
-                .credential(BearerTokenCredential.create(AuthenticationUtil.getBearerTokenSupplier(
-                        new DefaultAzureCredentialBuilder().build(), "https://cognitiveservices.azure.com/.default")))
+                .azureServiceVersion(AzureOpenAIServiceVersion.getV2024_05_01_PREVIEW())
+                // Disabling unified endpoints will result in the deployment name being passed as a path parameter
+                .unifiedAzureRoutes(false)
                 .build();
 
         ChatCompletionCreateParams createParams = ChatCompletionCreateParams.builder()
-                .model(ChatModel.GPT_4_1106_PREVIEW)
+                .model(ChatModel.of("DeepSeek-R1"))
                 .maxCompletionTokens(2048)
-                .addDeveloperMessage("Make sure you mention Stainless!")
+                .addSystemMessage("Make sure you mention Stainless!") // Developer doesn't work
                 .addUserMessage("Tell me a story about building the best SDK!")
                 .build();
 

--- a/openai-java-example/src/main/java/com/openai/example/AzureKeyCredentialExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/AzureKeyCredentialExample.java
@@ -1,6 +1,5 @@
 package com.openai.example;
 
-import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.azure.credential.AzureApiKeyCredential;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
@@ -13,7 +12,6 @@ public class AzureKeyCredentialExample {
     public static void main(String[] args) {
         OpenAIClient client = OpenAIOkHttpClient.builder()
                 .baseUrl("{your-azure-openai-endpoint}")
-                .azureServiceVersion(AzureOpenAIServiceVersion.fromString("preview"))
                 .credential(AzureApiKeyCredential.create("{your-azure-openai-key}"))
                 .build();
 

--- a/openai-java-example/src/main/java/com/openai/example/AzureKeyCredentialExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/AzureKeyCredentialExample.java
@@ -1,0 +1,31 @@
+package com.openai.example;
+
+import com.openai.azure.AzureOpenAIServiceVersion;
+import com.openai.azure.credential.AzureApiKeyCredential;
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.ChatModel;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+
+public class AzureKeyCredentialExample {
+    private AzureKeyCredentialExample() {}
+
+    public static void main(String[] args) {
+        OpenAIClient client = OpenAIOkHttpClient.builder()
+                .baseUrl("{your-azure-openai-endpoint}")
+                .azureServiceVersion(AzureOpenAIServiceVersion.fromString("preview"))
+                .credential(AzureApiKeyCredential.create("{your-azure-openai-key}"))
+                .build();
+
+        ChatCompletionCreateParams createParams = ChatCompletionCreateParams.builder()
+                .model(ChatModel.of("DeepSeek-R1"))
+                .maxCompletionTokens(2048)
+                .addSystemMessage("Make sure you mention Stainless!")
+                .addUserMessage("Tell me a story about building the best SDK!")
+                .build();
+
+        client.chat().completions().create(createParams).choices().stream()
+                .flatMap(choice -> choice.message().content().stream())
+                .forEach(System.out::println);
+    }
+}

--- a/openai-java-example/src/main/java/com/openai/example/AzureLegacyPathsEnabledExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/AzureLegacyPathsEnabledExample.java
@@ -6,16 +6,16 @@ import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 
-public final class AzureDisabledUnifiedEndpointsExample {
-    private AzureDisabledUnifiedEndpointsExample() {}
+public final class AzureLegacyPathsEnabledExample {
+    private AzureLegacyPathsEnabledExample() {}
 
     public static void main(String[] args) {
         OpenAIClient client = OpenAIOkHttpClient.builder()
                 // Gets the API key from the `AZURE_OPENAI_KEY` environment variable
                 .fromEnv()
                 .azureServiceVersion(AzureOpenAIServiceVersion.getV2024_05_01_PREVIEW())
-                // Disabling unified endpoints will result in the deployment name being passed as a path parameter
-                .unifiedAzureRoutes(false)
+                // Enabling Azure legacy paths will result in the deployment name being passed as a path parameter
+                .azureLegacyPaths(true)
                 .build();
 
         ChatCompletionCreateParams createParams = ChatCompletionCreateParams.builder()

--- a/openai-java-example/src/main/java/com/openai/example/AzureUnifiedEndpointExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/AzureUnifiedEndpointExample.java
@@ -1,29 +1,26 @@
 package com.openai.example;
 
-import com.azure.identity.AuthenticationUtil;
-import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
-import com.openai.credential.BearerTokenCredential;
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 
-public final class AzureEntraIdExample {
-    private AzureEntraIdExample() {}
+public final class AzureUnifiedEndpointExample {
+    private AzureUnifiedEndpointExample() {}
 
     public static void main(String[] args) {
         OpenAIClient client = OpenAIOkHttpClient.builder()
                 // Gets the API key from the `AZURE_OPENAI_KEY` environment variable
                 .fromEnv()
-                // Set the Azure Entra ID
-                .credential(BearerTokenCredential.create(AuthenticationUtil.getBearerTokenSupplier(
-                        new DefaultAzureCredentialBuilder().build(), "https://cognitiveservices.azure.com/.default")))
+                // TODO: remove preview once the api-version has become optional
+                .azureServiceVersion(AzureOpenAIServiceVersion.fromString("preview"))
                 .build();
 
         ChatCompletionCreateParams createParams = ChatCompletionCreateParams.builder()
-                .model(ChatModel.GPT_4_1106_PREVIEW)
+                .model(ChatModel.of("DeepSeek-R1"))
                 .maxCompletionTokens(2048)
-                .addDeveloperMessage("Make sure you mention Stainless!")
+                .addSystemMessage("Make sure you mention Stainless!") // Developer doesn't work
                 .addUserMessage("Tell me a story about building the best SDK!")
                 .build();
 

--- a/openai-java-example/src/main/java/com/openai/example/AzureUnifiedEndpointExample.java
+++ b/openai-java-example/src/main/java/com/openai/example/AzureUnifiedEndpointExample.java
@@ -1,6 +1,5 @@
 package com.openai.example;
 
-import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.models.ChatModel;
@@ -13,8 +12,6 @@ public final class AzureUnifiedEndpointExample {
         OpenAIClient client = OpenAIOkHttpClient.builder()
                 // Gets the API key from the `AZURE_OPENAI_KEY` environment variable
                 .fromEnv()
-                // TODO: remove preview once the api-version has become optional
-                .azureServiceVersion(AzureOpenAIServiceVersion.fromString("preview"))
                 .build();
 
         ChatCompletionCreateParams createParams = ChatCompletionCreateParams.builder()


### PR DESCRIPTION
Proposed changes:
- Adding necessary changes to support `v1/openai` Azure endpoints (referred to as "unified", as in "unified with the OpenAI schema", meaning that the model/deployment is not a path parameter of the request URL and `api-version` is optional).
- Currently the services still requires an `api-version` query parameter with the value of `preview`, but in the future the omission of this query parameter will result in resolving to `v1`
- Adding unit tests
- Adding samples showcasing:
  - `azureLegacyPaths` toggle (better name pending) allowing to manually force the old behaviour of adding deployment name to the path.
  - New hosts (`"services.ai.azure.com"`) are the new unified endpoints. 
  - Other hosts flagged as Azure, are treated the old way.
  - Adding `AzureKeyCredential` sample to supplement the `AzureEntraID` one.